### PR TITLE
Use safe-canvas module instead of dynamic check

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/vega/vega-wordcloud.git"
   },
   "scripts": {
-    "build": "uglifyjs build/vega-wordcloud.js -c -m -o build/vega-wordcloud.min.js",
+    "build": "npm run test && uglifyjs build/vega-wordcloud.js -c -m -o build/vega-wordcloud.min.js",
     "pretest": "rm -rf build && mkdir build && rollup -g vega-dataflow:vega,vega-scale:vega,vega-util:vega -f umd -n vega -o build/vega-wordcloud.js -- index.js",
     "test": "tape 'test/**/*-test.js' && eslint index.js src test",
     "prepublish": "npm run build",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postpublish": "git push && git push --tags && zip -j build/vega-wordcloud.zip -- LICENSE README.md build/vega-wordcloud.js build/vega-wordcloud.min.js"
   },
   "dependencies": {
-    "safe-canvas": "^1.1.0",
+    "safe-canvas": "^1.1.1",
     "vega-dataflow": ">=2.0.0-beta",
     "vega-scale": "1",
     "vega-util": "1"

--- a/package.json
+++ b/package.json
@@ -20,19 +20,17 @@
     "url": "https://github.com/vega/vega-wordcloud.git"
   },
   "scripts": {
-    "build": "npm run test && uglifyjs build/vega-wordcloud.js -c -m -o build/vega-wordcloud.min.js",
+    "build": "uglifyjs build/vega-wordcloud.js -c -m -o build/vega-wordcloud.min.js",
     "pretest": "rm -rf build && mkdir build && rollup -g vega-dataflow:vega,vega-scale:vega,vega-util:vega -f umd -n vega -o build/vega-wordcloud.js -- index.js",
     "test": "tape 'test/**/*-test.js' && eslint index.js src test",
     "prepublish": "npm run build",
     "postpublish": "git push && git push --tags && zip -j build/vega-wordcloud.zip -- LICENSE README.md build/vega-wordcloud.js build/vega-wordcloud.min.js"
   },
   "dependencies": {
+    "safe-canvas": "^1.1.0",
     "vega-dataflow": ">=2.0.0-beta",
     "vega-scale": "1",
     "vega-util": "1"
-  },
-  "optionalDependencies": {
-    "canvas": "^1.4.0"
   },
   "devDependencies": {
     "eslint": "2",

--- a/src/CloudLayout.js
+++ b/src/CloudLayout.js
@@ -366,9 +366,7 @@ function zeroArray(n) {
 
 function cloudCanvas() {
   try {
-    return typeof document !== 'undefined' && document.createElement
-      ? document.createElement('canvas')
-      : new (require('canvas'))();
+    return new require('safe-canvas')();
   } catch (e) {
     error('Canvas unavailable. Run in browser or install node-canvas.');
   }

--- a/src/CloudLayout.js
+++ b/src/CloudLayout.js
@@ -1,4 +1,5 @@
 import {error} from 'vega-util';
+import safeCanvas from 'safe-canvas';
 
 /*
 Copyright (c) 2013, Jason Davies.
@@ -365,11 +366,12 @@ function zeroArray(n) {
 }
 
 function cloudCanvas() {
-  try {
-    return new require('safe-canvas')();
-  } catch (e) {
-    error('Canvas unavailable. Run in browser or install node-canvas.');
+  var canvas = new safeCanvas();
+  if (canvas) {
+    return canvas;
   }
+
+  error('Canvas unavailable. Run in browser or install node-canvas.');
 }
 
 function functor(d) {


### PR DESCRIPTION
Currently if a user tries to bundle this module for use in the browser without having the `canvas` module installed things will fail (because bundlers will try to resolve everything ahead of time - the try/catch doesn't avoid this).

This PR instead has the code depend on [safe-canvas](https://github.com/mathisonian/safe-canvas) which will provide different code based on whether the package is being bundled by node or browserify/webpack/rollup and prevent builds from breaking if `canvas` isn't available.
